### PR TITLE
Enable strictDi angular bootstrap support

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,23 @@ beforeEach(function () {
 });
 ```
 
+## StrictDi and Bootstrap Config
+To set the AngularJS strictDi mode, or any future angular.boostrap config parameters, pass in an optional config object called bootstrapConfig:
+```js
+deferredBootstrapper.bootstrap({
+  element: document.body,
+  module: 'MyApp',
+  bootstrapConfig: {
+    strictDi: true
+  },
+  resolve: {
+    APP_CONFIG: ['$http', function ($http) {
+      return $http.get('/api/demo-config');
+    }]
+  }
+});
+```
+
 ## License
 
 [MIT](http://opensource.org/licenses/MIT) © Philipp Denzler

--- a/src/deferred-bootstrap.js
+++ b/src/deferred-bootstrap.js
@@ -42,6 +42,11 @@ function checkConfig (config) {
       throw new Error('\'config.resolve\' must be an object.');
     }
   }
+  if (config.bootstrapConfig) {
+    if (!isObject(config.bootstrapConfig)) {
+      throw new Error('\'config.bootstrapConfig\' must be an object.');
+    }
+  }
   if (config.moduleResolves) {
     if (!isArray(config.moduleResolves)) {
       throw new Error('\'config.moduleResolves\' must be an array.');
@@ -80,11 +85,11 @@ function createInjector (injectorModules, element) {
   return angular.injector(modules, element);
 }
 
-function doBootstrap (element, module) {
+function doBootstrap (element, module, bootstrapConfig) {
   var deferred = $q.defer();
 
   angular.element(document).ready(function () {
-    angular.bootstrap(element, [module]);
+    angular.bootstrap(element, [module], bootstrapConfig);
     removeLoadingClass();
 
     deferred.resolve(true);
@@ -100,7 +105,8 @@ function bootstrap (configParam) {
     injectorModules = config.injectorModules || [],
     injector,
     promises = [],
-    constants = [];
+    constants = [],
+    bootstrapConfig = config.bootstrapConfig;
 
   bodyElement = angular.element(document.body);
 
@@ -139,7 +145,7 @@ function bootstrap (configParam) {
       angular.module(moduleName).constant(constantName, result);
     });
 
-    return doBootstrap(element, module);
+    return doBootstrap(element, module, bootstrapConfig);
   }
 
   function handleError (error) {

--- a/test/deferred-bootstrap.spec.js
+++ b/test/deferred-bootstrap.spec.js
@@ -385,6 +385,36 @@ describe('deferredBootstrapper', function () {
       }).toThrow('\'config.resolve\' must be an object.');
     });
 
+    it('should throw if bootstrapConfig is not an object', function () {
+      var config = {
+        element: {},
+        module: 'myModule',
+        resolve: {
+          CONST: function () {
+          }
+        },
+        bootstrapConfig: 123
+      };
+      expect(function () {
+        checkConfig(config);
+      }).toThrow('\'config.bootstrapConfig\' must be an object.');
+    });
+
+    it('should accept valid deferred bootstrap config with bootstrapConfig option', function () {
+      var config = {
+        element: {},
+        module: 'myModule',
+        resolve: {
+          CONST: function () {
+          }
+        },
+        bootstrapConfig: {
+          strictDi: true
+        }
+      };
+      checkConfig(config);
+    });
+
     it('should throw if moduleResolves is not an array', function () {
       var config = {
         element: {},


### PR DESCRIPTION
Small patch to allow turning on the AngularJS 1.3 strictDi mode with a new bootstrapConfig optional object

``` js
deferredBootstrapper.bootstrap({
  element: document.body,
  module: 'MyApp',
  bootstrapConfig: {
    strictDi: true
  },
  resolve: {
    APP_CONFIG: ['$http', function ($http) {
      return $http.get('/api/demo-config');
    }]
  }
});
```
