### PR TITLE
Added support for CommonJS and AMD modules

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,5 +1,5 @@
 {
-  "predef": ["describe", "it", "beforeEach", "waitsFor", "expect", "angular", "spyOn", "jasmine"],
+  "predef": ["describe", "it", "beforeEach", "waitsFor", "expect", "angular", "spyOn", "jasmine", "define"],
   "esnext": false,
   "bitwise": true,
   "curly": true,

--- a/bower.json
+++ b/bower.json
@@ -5,6 +5,7 @@
   "authors": [
     "Philipp Denzler <philippd@gmail.com>"
   ],
+  "main": "angular-deferred-bootstrap.js",
   "license": "MIT",
   "ignore": [
     "**/.*",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "author": {
     "name": "Philipp Denzler"
   },
+  "main": "angular-deferred-bootstrap.js",
   "license": "MIT",
   "devDependencies": {
     "bower": "~1.3.8",

--- a/src/deferred-bootstrap.js
+++ b/src/deferred-bootstrap.js
@@ -171,6 +171,14 @@ function bootstrap (configParam) {
   return $q.all(promises).then(handleResults, handleError);
 }
 
-window.deferredBootstrapper = {
+var deferredBootstrapper = {
   bootstrap: bootstrap
 };
+
+if(typeof define === 'function' && define.amd) {
+  define(['deferredBootstrapper'], deferredBootstrapper);
+} else if(typeof module === 'object' && module.exports) {
+  module.exports = deferredBootstrapper;
+} else {
+  window.deferredBootstrapper = deferredBootstrapper;
+}


### PR DESCRIPTION
Hi, I added the support for CommonJS (e.g. Browserify/Webpack) and AMD (RequireJS) modules, I think this mendatory for every single front library to have this, it's simple and allows every one to use your library

Thanks for your work